### PR TITLE
Issue 40/feat/slide delimiter

### DIFF
--- a/app/Enums/SlideDelimiter.php
+++ b/app/Enums/SlideDelimiter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+enum SlideDelimiter: string
+{
+    use Traits\EnumToArray;
+
+    case DOUBLE_NEW_LINE = '(\n\n|\r\n)';
+    case THREE_DASHES = '---';
+
+    public const TOOLTIP = <<<'TOOLTIP'
+        This determines how your slides are broken apart. The simplest option
+        is Double New line, but if you need more control (such as when writing
+        formatted text or code), then the --- option may be better.
+    TOOLTIP;
+
+    /**
+     * Returns the user-friendly label
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::DOUBLE_NEW_LINE => 'Double New Line',
+            self::THREE_DASHES => '---',
+        };
+    }
+
+    /**
+     * Returns the user-friendly label
+     */
+    public function helperText(): string
+    {
+        return match ($this) {
+            self::DOUBLE_NEW_LINE => '2 newlines (i.e. hitting Enter twice)',
+            self::THREE_DASHES => '3 hyphens (---)',
+        };
+    }
+}

--- a/app/Filament/Resources/PresentationResource.php
+++ b/app/Filament/Resources/PresentationResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\SlideDelimiter;
 use App\Filament\Resources\PresentationResource\Pages;
 use App\Models\Presentation;
 use App\Models\User;
@@ -40,9 +41,10 @@ class PresentationResource extends Resource
                         Forms\Components\MarkdownEditor::make('content')
                             ->required()
                             ->default(Presentation::DEFAULT_MARKDOWN)
-                            ->hint(new HtmlString(
+                            ->hint(fn (Get $get) => new HtmlString(
                                 '<strong>Tip:</strong> '
-                                .'Slides are separated by 2 newlines.'
+                                .'Slides are separated by '
+                                .SlideDelimiter::tryFrom($get('slide_delimiter'))?->helperText()
                             ))->helperText(new HtmlString(
                                 'Want an example? See the site\'s '
                                 .'<u><a target="_blank" href="/instructions.md">instructions</a></u>.'
@@ -91,6 +93,17 @@ class PresentationResource extends Resource
                                         .'Limit is 160 characters.'
                                     )->placeholder('i.e. In this talk by Abraham Lincoln, we explore yada yada...')
                                     ->maxLength(160),
+
+                                Forms\Components\Select::make('slide_delimiter')
+                                    ->label('Slide Delimiter')
+                                    ->required()
+                                    ->live()
+                                    ->hintIcon('heroicon-o-information-circle',
+                                        tooltip: SlideDelimiter::TOOLTIP
+                                    )
+                                    ->selectablePlaceholder(false)
+                                    ->default(SlideDelimiter::DOUBLE_NEW_LINE->value)
+                                    ->options(SlideDelimiter::array()),
                                 SpatieMediaLibraryFileUpload::make('thumbnail')
                                     ->collection('thumbnail')
                                     ->image()

--- a/app/Http/Controllers/PresentationController.php
+++ b/app/Http/Controllers/PresentationController.php
@@ -27,6 +27,7 @@ class PresentationController extends Controller
 
         return Inertia::render('Slides', [
             'content' => $presentation->content,
+            'delimiter' => $presentation->slide_delimiter,
             'meta' => [
                 'title' => $presentation->title,
                 'description' => $presentation->description,

--- a/app/Models/Presentation.php
+++ b/app/Models/Presentation.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\SlideDelimiter;
 use Database\Factories\PresentationFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -45,6 +46,18 @@ class Presentation extends Model implements HasMedia
         'id',
         'deleted_at',
     ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'slide_delimiter' => SlideDelimiter::class,
+        ];
+    }
 
     /**
      * Determine if this presentation be viewed, based on published status and

--- a/database/factories/PresentationFactory.php
+++ b/database/factories/PresentationFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\SlideDelimiter;
 use App\Models\AggregateView;
 use App\Models\DailyView;
 use App\Models\Presentation;
@@ -77,6 +78,7 @@ class PresentationFactory extends Factory
             'is_published' => fake()->boolean(),
             'content' => "# My Presentation\n\n**Slide 1**\n\n*Slide 2*\n\nSlide 3",
             'user_id' => User::factory(),
+            'slide_delimiter' => SlideDelimiter::DOUBLE_NEW_LINE->value,
             'created_at' => now()->subDays(rand(0, 21)), // Sometime over the last 3 weeks
         ];
     }

--- a/database/migrations/2024_10_26_043110_add_slide_delimiter_to_presentations.php
+++ b/database/migrations/2024_10_26_043110_add_slide_delimiter_to_presentations.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('presentations', function (Blueprint $table) {
+            $table->string('slide_delimiter')->default('(\n\n|\r\n)');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('presentations', function (Blueprint $table) {
+            $table->dropColumn('slide_delimiter');
+        });
+    }
+};

--- a/resources/js/Pages/Slides.vue
+++ b/resources/js/Pages/Slides.vue
@@ -14,8 +14,9 @@ const props = defineProps<{
     index?: number,
     loop?: number,
     progress?: ProgressType,
-    slides?: string
-    content?: string
+    slides?: string,
+    content?: string,
+    delimiter?: string,
 }>();
 
 const processQueryParams = (): void =>  {
@@ -37,11 +38,11 @@ const getSlidesUrl = (): string => {
     return url;
 };
 
-onMounted(async () => {
+onMounted(() => {
     processQueryParams();
 
     if (props.content) {
-        dataStore.processData(props.content);
+        dataStore.processData(props.content, props.delimiter);
         return;
     }
 

--- a/resources/js/store/dataStore.ts
+++ b/resources/js/store/dataStore.ts
@@ -5,18 +5,18 @@ import { marked } from 'marked';
 const dataStore = reactive({
     data: <string[]>[],
 
-    async fetchAndProcessData(url: string) {
+    async fetchAndProcessData(url: string): Promise<void> {
         const response = await fetch(url);
         const body = await response.text();
 
+        // Not passing a delimiter, because this situation would always use
+        // the default delimiter.
         this.processData(body);
     },
 
-    processData(content: string) {
+    processData(content: string, delimiter: string = '(\n\n|\r\n)'): void {
         const parsedBody = content
-            .split("\n\n")
-            .map((content) => content.split("\r\n"))
-            .flat()
+            .split(new RegExp(delimiter))
             .filter((content) => content.trim().length > 0)
             .map((content) => {
                 const parsed = marked.parse(content, { async: false });

--- a/resources/js/test/store/dataStore.test.ts
+++ b/resources/js/test/store/dataStore.test.ts
@@ -3,52 +3,76 @@ import { MOCK_INSTRUCTIONS_URL, MOCK_WINDOWS_INSTRUCTIONS_URL } from '@/mocks/ha
 import { server } from '@/mocks/browser.ts';
 
 beforeEach(() => {
-  dataStore.reset()
+    dataStore.reset()
 })
 
 test('gets the right initial values', async () => {
-  expect(dataStore.data).toStrictEqual([]);
+    expect(dataStore.data).toStrictEqual([]);
 });
 
 test('can reset to initial values', async () => {
-  dataStore.data = ['1', '2', '3'];
+    dataStore.data = ['1', '2', '3'];
 
-  expect(dataStore.data).toStrictEqual(['1', '2', '3']);
+    expect(dataStore.data).toStrictEqual(['1', '2', '3']);
 
-  dataStore.reset();
+    dataStore.reset();
 
-  expect(dataStore.data).toStrictEqual([]);
+    expect(dataStore.data).toStrictEqual([]);
+});
+
+test('can process provided data with default delimiter', async () => {
+    const text = '1\n\n2\n\n3';
+
+    dataStore.processData(text);
+
+    expect(dataStore.data).toStrictEqual([
+        '<p>1</p>',
+        '<p>2</p>',
+        '<p>3</p>',
+    ]);
+});
+
+test('can process provided data with the triple hyphen delimiter', async () => {
+    const text = '1---2---3';
+
+    dataStore.processData(text, '---');
+
+    expect(dataStore.data).toStrictEqual([
+        '<p>1</p>',
+        '<p>2</p>',
+        '<p>3</p>',
+    ]);
 });
 
 describe('fetching data', () => {
-  // Start server before all tests
-  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+    // Start server before all tests
+    beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 
-  //  Close server after all tests
-  afterAll(() => server.close())
+    //  Close server after all tests
+    afterAll(() => server.close())
 
-  // Reset handlers after each test `important for test isolation`
-  afterEach(() => server.resetHandlers())
+    // Reset handlers after each test `important for test isolation`
+    afterEach(() => server.resetHandlers())
 
-  test('gets the instructions', async () => {
-    expect(dataStore.data).toStrictEqual([]);
+    test('gets the instructions', async () => {
+        expect(dataStore.data).toStrictEqual([]);
 
-    await dataStore.fetchAndProcessData(MOCK_INSTRUCTIONS_URL);
+        await dataStore.fetchAndProcessData(MOCK_INSTRUCTIONS_URL);
 
-    expect(dataStore.data.length).toBe(3);
-    expect(dataStore.data[0]).toBe('<p>Welcome to</p>');
-    expect(dataStore.data[1]).toBe('<h1>Simple Slides</h1>');
-    expect(dataStore.data[2]).toBe('<p><a href="https://example.com">https://example.com</a></p>');
-  });
+        expect(dataStore.data.length).toBe(3);
+        expect(dataStore.data[0]).toBe('<p>Welcome to</p>');
+        expect(dataStore.data[1]).toBe('<h1>Simple Slides</h1>');
+        expect(dataStore.data[2]).toBe('<p><a href="https://example.com">https://example.com</a></p>');
+    });
 
-  test('gets the instructions with \r\n data', async () => {
-    expect(dataStore.data).toStrictEqual([]);
+    test('gets the instructions with \r\n data', async () => {
+        expect(dataStore.data).toStrictEqual([]);
 
-    await dataStore.fetchAndProcessData(MOCK_WINDOWS_INSTRUCTIONS_URL);
+        await dataStore.fetchAndProcessData(MOCK_WINDOWS_INSTRUCTIONS_URL);
 
-    expect(dataStore.data.length).toBe(3);
-    expect(dataStore.data[0]).toBe('<p>Welcome to</p>');
-    expect(dataStore.data[1]).toBe('<h1>Simple Slides</h1>');
-    expect(dataStore.data[2]).toBe('<p><a href="https://example.com">https://example.com</a></p>');
-  });
+        expect(dataStore.data.length).toBe(3);
+        expect(dataStore.data[0]).toBe('<p>Welcome to</p>');
+        expect(dataStore.data[1]).toBe('<h1>Simple Slides</h1>');
+        expect(dataStore.data[2]).toBe('<p><a href="https://example.com">https://example.com</a></p>');
+    });
 });

--- a/tests/Feature/PresentationControllerTest.php
+++ b/tests/Feature/PresentationControllerTest.php
@@ -87,6 +87,7 @@ describe('published presentation', function () {
         $response->assertInertia(fn (Assert $page) => $page
             ->component('Slides')
             ->where('content', $this->publishedPresentation->content)
+            ->where('delimiter', $this->publishedPresentation->slide_delimiter)
             ->has('meta', fn (Assert $page) => $page
                 ->where('title', $this->publishedPresentation->title)
                 ->where('description', $this->publishedPresentation->description)


### PR DESCRIPTION
Completes #40 

Adds in a new "Slide Delimiter" field to presentations that allows the user to determine how slides should be separated.

<img width="511" alt="Screenshot 2025-02-27 at 11 33 39 AM" src="https://github.com/user-attachments/assets/621fbd2f-11c8-45b2-ae63-13bf20d054ea" />
